### PR TITLE
Refine the proof of concept

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 frontend/build
 .serverless
 .webpack
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -4,6 +4,65 @@ This simple POC shows a good way to create a [user-friendly magic link login sys
 
 While functional and safe, this is not production-style code.
 
+## How to run this example
+
+### 1. Download and install dependencies
+
+```
+git clone git@github.com:mojitocoder/serverless-magic-links-poc.git
+cd serverless-magic-links-poc
+npm install
+```
+
+### 2. Create your unique environment
+
+This step is optional. You can skip this step if you are the only person to deploy this solution to a unique combination of AWS Account + AWS Region.
+
+To ensure the deployment does not fail or interupt with another deployment from a different user, make two changes as follows::
+
+1. Open `$/frontend/package.json`, change the value of `homepage` to a unique value, e.g. `lewis`.
+2. Open `$/serverless.yml`, make a similar change for `custom.stage` tag, e.g from ` stage: ${opt:stage, 'quynh'}` to ` stage: ${opt:stage, 'lewis'}`
+
+### 3. Deploy the project
+
+You will need to deploy the project twice to make it work properly. The sequence is: Deploy => Get some returned values to make changes to the frontend's settings => Deploy again to push updated frontend.
+
+1. Run `npm run deploy` to do the first deployment
+
+2. Capture the URL listed in `endpoints`' `POST` value, it looks like this:
+   ```
+   endpoints:
+     POST - https://h3avtopjn8.execute-api.eu-west-1.amazonaws.com/quynh/login
+   ```
+Note: If you lost the output of the previous `npm run deploy` command on the terminal, you can run `npm run sls -- info` to get the information back.
+
+3. Open `$/frontend/src/components/LoginForm.js`, replace the value of constant `loginUrl` (line 4) with the captured URL.
+
+4. Run `npm run sls -- info --verbose` to get the values of `UserPoolClientId` and `UserPoolId` from the `Stack Outputs`. They look like this:
+
+   ```
+   Stack Outputs
+   UserPoolClientId: 3l4s9hjp44tiq0jpab3f4nlhrj
+   UserPoolId: eu-west-1_v0L9STrqo
+   ```
+
+5. Put these two values into the appropriate places in `$/frontend/src/authConfig.js`. Whilst you are here, remember to change the `region` value in this file if this service is deployed to a different region from the default of `eu-west-1`.
+
+6. Deploy the project again using `npm run deploy` to push the latest changes to the frontend to AWS.
+
+### 4. Create users
+
+Before you can test the magic link, you need to create at least one user in the UserPool.
+
+1. Head AWS web console, go to `Cognito` service then `Manage User Pools`, e.g. https://eu-west-1.console.aws.amazon.com/cognito/users/?region=eu-west-1
+2. Select the pool created by your service, e.g. `sls-magic-link-poc-user-pool-lewis`
+3. Go to `General settings \ Users and groups` to create a user. Use an email for username.
+
+### 5. Test magic links 
+
+1. Go to the login page's URL of your service, e.g. `https://h3avtopjn8.execute-api.eu-west-1.amazonaws.com/quynh`
+2. Make sure you put in an email address of a user you have already created in the previous step.
+
 
 ## User experience
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ You will need to deploy the project twice to make it work properly. The sequence
    endpoints:
      POST - https://h3avtopjn8.execute-api.eu-west-1.amazonaws.com/quynh/login
    ```
+
 Note: If you lost the output of the previous `npm run deploy` command on the terminal, you can run `npm run sls -- info` to get the information back.
 
 3. Open `$/frontend/src/components/LoginForm.js`, replace the value of constant `loginUrl` (line 4) with the captured URL.
@@ -62,6 +63,14 @@ Before you can test the magic link, you need to create at least one user in the 
 
 1. Go to the login page's URL of your service, e.g. `https://h3avtopjn8.execute-api.eu-west-1.amazonaws.com/quynh`
 2. Make sure you put in an email address of a user you have already created in the previous step.
+
+## Clean up
+
+Once you have finished with your testing, make sure you run:
+```
+npm run sls -- remove
+```
+to remove all the artefacts of your service from AWS.
 
 
 ## User experience

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ This step is optional. You can skip this step if you are the only person to depl
 To ensure the deployment does not fail or interupt with another deployment from a different user, make two changes as follows::
 
 1. Open `$/frontend/package.json`, change the value of `homepage` to a unique value, e.g. `lewis`.
-2. Open `$/serverless.yml`, make a similar change for `custom.stage` tag, e.g from ` stage: ${opt:stage, 'quynh'}` to ` stage: ${opt:stage, 'lewis'}`
+2. Open `$/frontend/src/App.js`, change the value of `basename` to your value, e.g. `lewis`
+3. Open `$/serverless.yml`, make a similar change for `custom.stage` tag, e.g from ` stage: ${opt:stage, 'quynh'}` to ` stage: ${opt:stage, 'lewis'}`
 
 ### 3. Deploy the project
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To ensure the deployment does not fail or interupt with another deployment from 
 
 1. Open `$/frontend/package.json`, change the value of `homepage` to a unique value, e.g. `lewis`.
 2. Open `$/frontend/src/App.js`, change the value of `basename` to your value, e.g. `lewis`
-3. Open `$/serverless.yml`, make a similar change for `custom.stage` tag, e.g from ` stage: ${opt:stage, 'quynh'}` to ` stage: ${opt:stage, 'lewis'}`
+3. Open `$/serverless.yml`, make a similar change for `custom.stage` tag, e.g from ` stage: ${opt:stage, 'dev'}` to ` stage: ${opt:stage, 'lewis'}`
 
 ### 3. Deploy the project
 
@@ -33,7 +33,7 @@ You will need to deploy the project twice to make it work properly. The sequence
 2. Capture the URL listed in `endpoints`' `POST` value, it looks like this:
    ```
    endpoints:
-     POST - https://h3avtopjn8.execute-api.eu-west-1.amazonaws.com/quynh/login
+     POST - https://h3avtopjn8.execute-api.eu-west-1.amazonaws.com/dev/login
    ```
 
 Note: If you lost the output of the previous `npm run deploy` command on the terminal, you can run `npm run sls -- info` to get the information back.
@@ -62,7 +62,7 @@ Before you can test the magic link, you need to create at least one user in the 
 
 ### 5. Test magic links 
 
-1. Go to the login page's URL of your service, e.g. `https://h3avtopjn8.execute-api.eu-west-1.amazonaws.com/quynh`
+1. Go to the login page's URL of your service, e.g. `https://h3avtopjn8.execute-api.eu-west-1.amazonaws.com/dev`
 2. Make sure you put in an email address of a user you have already created in the previous step.
 
 ## Clean up

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,7 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
-  "homepage": "/dev",
+  "homepage": "/quynh",
   "eslintConfig": {
     "extends": "react-app"
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,7 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
-  "homepage": "/quynh",
+  "homepage": "/dev",
   "eslintConfig": {
     "extends": "react-app"
   },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "devDependencies": {
     "aws-sdk": "^2.715.0",
-    "serverless": "^1.75.1",
+    "serverless": "^2.8.0",
     "serverless-apigateway-service-proxy": "^1.10.0",
     "serverless-s3-sync": "^1.14.4"
   },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "description": "A simple POC implementation of best-practice UX for magic links.",
   "author": "Thomas Schoffelen <thomas@schof.co>",
   "scripts": {
-    "deploy": "cd frontend && yarn install && yarn build && cd .. && npx serverless deploy"
+    "deploy": "cd frontend && yarn install && yarn build && cd .. && npx serverless deploy",
+    "sls": "serverless"
   },
   "license": "MIT",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "A simple POC implementation of best-practice UX for magic links.",
   "author": "Thomas Schoffelen <thomas@schof.co>",
   "scripts": {
-    "deploy": "cd frontend && yarn build && cd .. && serverless deploy"
+    "deploy": "cd frontend && yarn install && yarn build && cd .. && npx serverless deploy"
   },
   "license": "MIT",
   "devDependencies": {

--- a/serverless.yml
+++ b/serverless.yml
@@ -130,7 +130,7 @@ package:
     - node_modules/aws-sdk/**
 
 custom:
-  stage: ${opt:stage, 'quynh'}
+  stage: ${opt:stage, 'dev'}
   userPoolName: sls-magic-link-poc-user-pool-${self:custom.stage}
   userPoolClientName: sls-magic-link-poc-pool-client-${self:custom.stage}
   webBucketName: sls-magic-link-poc-web-${self:custom.stage}

--- a/serverless.yml
+++ b/serverless.yml
@@ -18,6 +18,7 @@ functions:
       - cognitoUserPool:
           pool: ${self:custom.userPoolName}
           trigger: DefineAuthChallenge
+          existing: true
 
   # 2. Create the actual auth challenge
   create-auth-challenge:
@@ -26,6 +27,7 @@ functions:
       - cognitoUserPool:
           pool: ${self:custom.userPoolName}
           trigger: CreateAuthChallenge
+          existing: true
 
   # 3. Verify auth challenge
   verify-auth-challenge:
@@ -34,6 +36,7 @@ functions:
       - cognitoUserPool:
           pool: ${self:custom.userPoolName}
           trigger: VerifyAuthChallengeResponse
+          existing: true
 
 # Set up Cognito & S3
 resources:
@@ -118,8 +121,8 @@ package:
     - node_modules/aws-sdk/**
 
 custom:
-  userPoolName: poc-user-pool
-  userPoolClientName: poc-user-pool-client
+  userPoolName: sls-magic-link-poc-user-pool
+  userPoolClientName: sls-magic-link-poc-pool-client
   webBucketName: sls-magic-link-poc-web
   apiGatewayServiceProxies:
     - s3:

--- a/serverless.yml
+++ b/serverless.yml
@@ -96,6 +96,13 @@ resources:
           IndexDocument: index.html
           ErrorDocument: index.html
 
+  Outputs:
+    UserPoolId: 
+      Value: !Ref UserPool
+    UserPoolClientId:
+      Value: !Ref UserPoolClient
+    
+
 # Default serverless stuff
 provider:
   name: aws

--- a/serverless.yml
+++ b/serverless.yml
@@ -1,5 +1,7 @@
 service: poc-magic-links
 
+frameworkVersion: '2'
+
 # Attaching handlers
 functions:
   # 0. Initiates sign-in

--- a/serverless.yml
+++ b/serverless.yml
@@ -18,7 +18,6 @@ functions:
       - cognitoUserPool:
           pool: ${self:custom.userPoolName}
           trigger: DefineAuthChallenge
-          existing: true
 
   # 2. Create the actual auth challenge
   create-auth-challenge:
@@ -27,7 +26,6 @@ functions:
       - cognitoUserPool:
           pool: ${self:custom.userPoolName}
           trigger: CreateAuthChallenge
-          existing: true
 
   # 3. Verify auth challenge
   verify-auth-challenge:
@@ -36,7 +34,6 @@ functions:
       - cognitoUserPool:
           pool: ${self:custom.userPoolName}
           trigger: VerifyAuthChallengeResponse
-          existing: true
 
 # Set up Cognito & S3
 resources:
@@ -89,7 +86,7 @@ resources:
     WebBucket:
       Type: "AWS::S3::Bucket"
       Properties:
-        BucketName: poc-user-pool-web
+        BucketName: ${self:custom.webBucketName}
         WebsiteConfiguration:
           IndexDocument: index.html
           ErrorDocument: index.html
@@ -97,7 +94,6 @@ resources:
 # Default serverless stuff
 provider:
   name: aws
-  profile: schof
   runtime: nodejs10.x
   region: eu-west-1
   stage: dev
@@ -124,6 +120,7 @@ package:
 custom:
   userPoolName: poc-user-pool
   userPoolClientName: poc-user-pool-client
+  webBucketName: sls-magic-link-poc-web
   apiGatewayServiceProxies:
     - s3:
         path: /
@@ -151,7 +148,7 @@ custom:
           Ref: WebBucket
         cors: true
   s3Sync:
-    - bucketName: poc-user-pool-web
+    - bucketName: ${self:custom.webBucketName}
       localDir: frontend/build/
       acl: public-read
       followSymlinks: true

--- a/serverless.yml
+++ b/serverless.yml
@@ -101,7 +101,7 @@ provider:
   name: aws
   runtime: nodejs10.x
   region: eu-west-1
-  stage: dev
+  stage: ${self:custom.stage}
   environment:
     URL: {"Fn::Join": ["", ["https://", {"Ref": "ApiGatewayRestApi"}, ".execute-api.${self:provider.region}.amazonaws.com/${self:provider.stage}"]]}
     USER_POOL_ID: {"Ref": "UserPool"}
@@ -123,9 +123,11 @@ package:
     - node_modules/aws-sdk/**
 
 custom:
-  userPoolName: sls-magic-link-poc-user-pool
-  userPoolClientName: sls-magic-link-poc-pool-client
-  webBucketName: sls-magic-link-poc-web
+  stage: ${opt:stage, 'quynh'}
+  userPoolName: sls-magic-link-poc-user-pool-${self:custom.stage}
+  userPoolClientName: sls-magic-link-poc-pool-client-${self:custom.stage}
+  webBucketName: sls-magic-link-poc-web-${self:custom.stage}
+
   apiGatewayServiceProxies:
     - s3:
         path: /


### PR DESCRIPTION
Why
====
+ There are a couple of bugs with the current solution
+ There is not enough instruction for developers to easily follow and deploy the solution
+ It's not possible for the solution to be deployed as two instances to the same AWS account

What
====
+ Fixed the small bugs
+ Upgraded to `serverless` v2
+ Added detailed instruction to deploy in README.md

Future direction
====
+ Centralise the homepage value, e.g. `dev` into one variable for the frontend. It would best to inherit it from the variable set in `serverless.yml`
+ Get the Cognito user pool info (userpool id, userpool client id, region) from the serverless deployment and inject them into the frontend. Maybe something link `serverless-export-env` would help.